### PR TITLE
Add proper error handling to count() method in Jest Client

### DIFF
--- a/models/JestClient.cfc
+++ b/models/JestClient.cfc
@@ -250,6 +250,14 @@ component
 
 		var searchResult = execute( jCountBuilder.build() );
 
+		if ( structKeyExists( searchResult, "error" ) ){
+			throw(
+				type="cbElasticsearch.JestClient.IndexCountException",
+				message=( isSimpleValue( searchResult.error ) ? searchResult.error : searchResult.error.reason ),
+				extendedInfo=serializeJSON( searchResult[ "error" ], false, listFindNoCase( "Lucee", server.coldfusion.productname ) ? "utf-8" : false )
+			);
+		}
+
 		return searchResult[ "count" ];
 
 	}


### PR DESCRIPTION
Bad `count()` queries are currently un-debuggable, because cbElasticsearch gives an error when `searchResult["count"]` does not exist.

This PR adds simple error handling (a throw) if Elasticsearch returns an `error` struct from a `count` call.